### PR TITLE
Add the plugin for stripping flow types

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ module.exports = {
     require('babel-preset-stage-0')
   ],
 
-  /**
-   * babel-preset-es2015 plugins
-   */
   plugins: [
+    /**
+     * babel-preset-es2015 plugins
+     */
     require('babel-plugin-transform-es2015-template-literals'),
     require('babel-plugin-transform-es2015-literals'),
     require('babel-plugin-transform-es2015-function-name'),
@@ -39,6 +39,11 @@ module.exports = {
      * @see https://babeljs.io/docs/usage/caveats/
      */
     [require('babel-plugin-transform-es2015-classes'), { loose: true }],
-    require('babel-plugin-transform-proto-to-assign')
+    require('babel-plugin-transform-proto-to-assign'),
+
+    /**
+     * flowtype plugin
+     */
+    require('babel-plugin-transform-flow-strip-types')
   ]
 }

--- a/package.json
+++ b/package.json
@@ -46,11 +46,9 @@
   "devDependencies": {
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.5",
-    "eslint-plugin-flowtype": "^2.2.7",
     "standard": "^7.0.1"
   },
   "standard": {
-    "parser": "babel-eslint",
-    "plugins": ["flowtype"]
+    "parser": "babel-eslint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-transform-es2015-template-literals": "^6.6.0",
     "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-proto-to-assign": "^6.8.0",
     "babel-plugin-transform-regenerator": "^6.6.0",
     "babel-preset-react": "^6.5.0",
@@ -44,6 +45,12 @@
   },
   "devDependencies": {
     "babel-core": "^6.8.0",
+    "babel-eslint": "^6.0.5",
+    "eslint-plugin-flowtype": "^2.2.7",
     "standard": "^7.0.1"
+  },
+  "standard": {
+    "parser": "babel-eslint",
+    "plugins": ["flowtype"]
   }
 }

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,5 +1,5 @@
 type TheA = {
-  a : number,
+  a: number,
   b: string
 }
 
@@ -9,7 +9,7 @@ class A {
   }
 }
 
-const createTheA = () : TheA => ({
+const createTheA = (): TheA => ({
   a: 10,
   b: 'text'
 })

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -1,12 +1,23 @@
+type TheA = {
+  a : number,
+  b: string
+}
+
 class A {
   constructor () {
     console.log('A')
   }
 }
 
+const createTheA = () : TheA => ({
+  a: 10,
+  b: 'text'
+})
+
 export default class B extends A {
   constructor () {
     super()
+    createTheA()
     console.log('B')
   }
 }


### PR DESCRIPTION
This is WIP just because the eslint-plugin-flowtype works for ignoring the flowtype checks, but doesn't lint the flow related syntax. I'd like to figure out a way of making that work before merging. 
