### PR TITLE
Update and fix versions of devDeps 📺

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "babel-preset-stage-0": "^6.5.0"
   },
   "devDependencies": {
-    "babel-core": "^6.8.0",
-    "babel-eslint": "^6.0.5",
-    "standard": "^7.0.1"
+    "babel-core": "6.8.0",
+    "babel-eslint": "6.1.0",
+    "standard": "7.0.1"
   },
   "standard": {
     "parser": "babel-eslint"


### PR DESCRIPTION
- `babel-eslint` to 6.1.0 to match dep in https://github.com/saguijs/eslint-config-sagui/pull/1
- Fix all of the versions to be consistent with next approach

Should I also fix the versions of the peerDeps? It seems like it could make sense, but I haven't given it much thought.
